### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*.o
+*.ko
+*.mod.c
+*~
+.*.cmd
+*.o.cmd
+.*.o.cmd
+Module.symvers
+modules.order
+.tmp_versions
+modules.builtin


### PR DESCRIPTION
Add a .gitignore with the files created when building the bcm4334x.ko module, so "make" doesn't leave the repo in a dirty state.
